### PR TITLE
TI-3067 Update e2e runner from ubuntu-20.04 to ubuntu-latest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
         run: pnpm test
 
   e2e:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Updates the e2e job runner from the deprecated ubuntu-20.04 to ubuntu-latest to fix runner availability issues. The current Ubuntu runner (24.04) remains fully compatible with pnpm 8.15.4, Node.js 20.x, and all project dependencies.